### PR TITLE
Label ship explosion pieces velocity and fix label

### DIFF
--- a/content/Arcade/Asteroids/VectorROM.mark
+++ b/content/Arcade/Asteroids/VectorROM.mark
@@ -168,11 +168,13 @@ line pattern in the center.
 08E8: C7 F1          SVEC scale=00(/512) bri=12    x=-3      y=1       (-0.0059, 0.0020)
 08EA: C1 FD          SVEC scale=01(/256) bri=12    x=1       y=-1      (0.0039, -0.0117)
 
-; Data of some kind
-08EC: D8 1E 32 EC
-08F0: 00 C4
-08F2: 3C 14 0A 46
-08F6: D8 D8
+; Ship explosion pieces velocity (x, y)
+08EC: D8 1E (-40,  30)
+08EE: 32 EC ( 50, -20)
+08F0: 00 C4 (  0, -60)
+08F2: 3C 14 ( 60,  20)
+08F4: 0A 46 ( 10,  70)
+08F6: D8 D8 (-40, -40)
 
 # Shrapnel Patterns `visual`
 

--- a/content/Arcade/Asteroids/VectorROM.mark
+++ b/content/Arcade/Asteroids/VectorROM.mark
@@ -446,7 +446,7 @@ can be used to take up the gaps in the large scaling doubles!
 }}}
 
 ShipDir0:
-0A90: 0F F6    VEC  scale=05(/16)  bri=15    x=-527    y=-194    (-32.9375, -12.1250)
+0A90: 0F F6          SVEC scale=02(/128) bri=0     x=-3      y=-2      (-0.0234, -0.0156)
 0A92: C8 FA          SVEC scale=03(/64)  bri=12    x=0       y=2       (0.0000, 0.0313)
 0A94: BD F9          SVEC scale=03(/64)  bri=11    x=-1      y=1       (-0.0156, 0.0156)
 0A96: 00 65 00 C3    VEC  scale=06(/8)   bri=12    x=768     y=-256    (96.0000, -32.0000)


### PR DESCRIPTION
I thought these looked suspicious hanging out right under the ship explosion.
Turns out the explosion pieces move out from the ship location based on the ship status and these values.
Also fixed an incorrect label for the first ship vector.